### PR TITLE
Change key of error message in JWT

### DIFF
--- a/api/quizard_backend/__init__.py
+++ b/api/quizard_backend/__init__.py
@@ -12,6 +12,7 @@ app = Sanic(__name__)
 app.config.update(SANIC_CONFIG)
 app.config["JWT_SECRET_KEY"] = JWT_SECRET_KEY
 app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(minutes=15)
+app.config["JWT_ERROR_MESSAGE_KEY"] = "error"
 app.config["CORS_AUTOMATIC_OPTIONS"] = True
 
 # Note: Gino doesn't auto-generate any new changes in the schema


### PR DESCRIPTION
- Change from the default key of `msg` to `error`.