### PR TITLE
Make error msg consistent

### DIFF
--- a/api/quizard_backend/exceptions.py
+++ b/api/quizard_backend/exceptions.py
@@ -14,6 +14,8 @@ async def sanic_error_handler(request, exception):
     if hasattr(exception, "status_code"):
         status_code = exception.status_code
 
+    if isinstance(exc_message, str):
+        exc_message = {"msg": [exc_message]}
     return json({"error": exc_message}, status=status_code)
 
 

--- a/api/quizard_backend/utils/crypto.py
+++ b/api/quizard_backend/utils/crypto.py
@@ -22,6 +22,10 @@ def validate_password_strength(password: str):
         return
 
     raise InvalidUsage(
-        "Your password is not strong enough. "
-        "Ensure it has at least 8 characters, and at least 1 number."
+        {
+            "password": [
+                "Your password is not strong enough. "
+                "Ensure it has at least 8 characters, and at least 1 number."
+            ]
+        }
     )

--- a/api/quizard_backend/utils/views/quiz_question.py
+++ b/api/quizard_backend/utils/views/quiz_question.py
@@ -1,5 +1,4 @@
 from sanic.exceptions import Forbidden
-
 from quizard_backend.models import Quiz, QuizQuestion
 from quizard_backend.utils.query import get_many
 


### PR DESCRIPTION
Right now the error message is either in `List` format or `String`.

1. For all input validation errors, return:
```
{
  "error": {
    <key>: [ <error_msg> ],
    ...
  }
}
```

2. For other string-based error msg, return:
```
{
  "error": {
    "msg": [ <error_msg> ],
  }
}
```